### PR TITLE
Update AWS Terraform config to add VPC

### DIFF
--- a/aws/terraform/hosts.tf
+++ b/aws/terraform/hosts.tf
@@ -25,6 +25,35 @@ resource "aws_subnet" "boundary_hosts_subnet" {
   }
 }
 
+# enable these resources if you want to enable SSH access to the instances later via
+# Boundary. You will also need to provide the key_name attribute to aws_instance
+#
+# resource "aws_internet_gateway" "boundary_gateway" { vpc_id =
+#   aws_vpc.boundary_hosts_vpc.id
+
+#   tags = {
+#     Name = "boundary_hosts_internet_gateway"
+#   }
+# }
+
+# resource "aws_route_table" "boundary_hosts_public_rt" {
+#   vpc_id = aws_vpc.boundary_hosts_vpc.id
+
+#   route {
+#     cidr_block = "0.0.0.0/0"
+#     gateway_id = aws_internet_gateway.boundary_gateway.id
+#   }
+
+#   tags = {
+#     Name = "boundary_hosts_public_route_table"
+#   }
+# }
+
+# resource "aws_route_table_association" "public_1_rt_a" {
+#   subnet_id      = aws_subnet.boundary_hosts_subnet.id
+#   route_table_id = aws_route_table.boundary_hosts_public_rt.id
+# }
+
 resource "aws_security_group" "boundary_ssh" {
   name        = "boundary_allow_ssh"
   description = "Allow SSH inbound traffic"
@@ -64,6 +93,7 @@ resource "aws_instance" "boundary_instance" {
   count                  = length(var.instances)
   ami                    = "ami-083602cee93914c0c"
   instance_type          = "t3.micro"
+#  key_name               = "NAME_OF_EC2_KEYPAIR" # enable to log in to the instances
   subnet_id              = aws_subnet.boundary_hosts_subnet.id
   vpc_security_group_ids = [aws_security_group.boundary_ssh.id]
   tags                   = var.vm_tags[count.index]

--- a/aws/terraform/hosts.tf
+++ b/aws/terraform/hosts.tf
@@ -1,7 +1,47 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-# Configure the AWS hosts
+# Configure the AWS VM hosts
+
+data "aws_availability_zones" "boundary" {}
+
+resource "aws_vpc" "boundary_hosts_vpc" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "boundary_hosts_vpc"
+  }
+}
+
+resource "aws_subnet" "boundary_hosts_subnet" {
+  vpc_id                  = aws_vpc.boundary_hosts_vpc.id
+  cidr_block              = aws_vpc.boundary_hosts_vpc.cidr_block
+  availability_zone       = data.aws_availability_zones.boundary.names[0]
+  map_public_ip_on_launch = true
+  
+  tags = {
+    Name = "boundary_hosts_subnet"
+  }
+}
+
+resource "aws_security_group" "boundary_ssh" {
+  name        = "boundary_allow_ssh"
+  description = "Allow SSH inbound traffic"
+  vpc_id      = aws_vpc.boundary_hosts_vpc.id
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "allow_ssh"
+  }
+}
+
 variable "instances" {
   default = [
     "boundary-1-dev", 
@@ -20,28 +60,11 @@ variable "vm_tags" {
   ]
 }
 
-resource "aws_security_group" "boundary-ssh" {
-  name        = "boundary_allow_ssh"
-  description = "Allow SSH inbound traffic"
-
-  ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = {
-    Name = "allow_ssh"
-  }
-}
-
-resource "aws_instance" "boundary-instance" {
+resource "aws_instance" "boundary_instance" {
   count                  = length(var.instances)
   ami                    = "ami-083602cee93914c0c"
   instance_type          = "t3.micro"
-  availability_zone      = "us-east-1a"
-  security_groups        = ["boundary_allow_ssh"]
-  vpc_security_group_ids = ["${aws_security_group.boundary-ssh.id}"]
+  subnet_id              = aws_subnet.boundary_hosts_subnet.id
+  vpc_security_group_ids = [aws_security_group.boundary_ssh.id]
   tags                   = var.vm_tags[count.index]
 }


### PR DESCRIPTION
This PR adds these Terraform resources to the `aws/hosts.tf` config to avoid using the default AWS VPC. If a default VPC isn't configured, Terraform will throw an error. This addition creates a VPC and associated resources to avoid this problem.

- `aws_availability_zone` 
- `aws_vpc`
- `aws_subnet`

See the associated tutorial PR for more context:

https://github.com/hashicorp/tutorials/pull/1661